### PR TITLE
Test harness and cancel withdrawal

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -13,7 +13,3 @@ url = "https://anchor.projectserum.com"
 [provider]
 cluster = "devnet"
 wallet = "~/.config/solana/id.json"
-
-[scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/rfq.spec.ts"
-#test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/psyamerican.spec.ts"

--- a/tests/integration/Test.toml
+++ b/tests/integration/Test.toml
@@ -1,0 +1,2 @@
+[scripts]
+test = "yarn run ts-mocha -t 1000000 -p ./tsconfig.json tests/integration/rfq.spec.ts"

--- a/tests/integration/psyamerican.spec.ts
+++ b/tests/integration/psyamerican.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * PsyAmerican Specification
+ */
+
+import * as anchor from "@project-serum/anchor";
+import { Wallet, BN } from "@project-serum/anchor";
+import * as assert from "assert";
+import { Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { Keypair, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+
+import {
+  PROTOCOL_SEED,
+  RFQ_SEED,
+  BuySell,
+  Contract,
+  Instrument,
+  Order,
+  Quote,
+  Venue,
+  calcFee,
+  confirm,
+  getBalance,
+  getProgram,
+  processLegs,
+  respond,
+  request,
+  requestAirdrop,
+  settle,
+} from "../../lib/helpers";
+import { Program } from "@project-serum/anchor";
+
+let assetToken: Token;
+let quoteToken: Token;
+
+const ASSET_DECIMALS = 6;
+const QUOTE_DECIMALS = 2;
+
+const MINT_AIRDROP_ASSET = 1_000_000 * 10 ** ASSET_DECIMALS;
+const MINT_AIRDROP_QUOTE = 10_000_000_000_000 * 10 ** QUOTE_DECIMALS;
+
+const FEE_NUMERATOR = 1;
+const FEE_DENOMINATOR = 1_000;
+
+const TAKER_ORDER_AMOUNT1 = 5 * 10 ** ASSET_DECIMALS;
+const TAKER_ORDER_AMOUNT2 = 32 * 10 ** ASSET_DECIMALS;
+
+const MAKER_A_ASK_AMOUNT1 = 0 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT1;
+const MAKER_A_BID_AMOUNT1 = 39_100 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT1;
+
+const FEE1 = calcFee(MAKER_A_BID_AMOUNT1, FEE_NUMERATOR, FEE_DENOMINATOR);
+
+let takerAssetATA: PublicKey;
+let takerQuoteATA: PublicKey;
+let makerAAssetATA: PublicKey;
+let makerAQuoteATA: PublicKey;
+
+let mintAuthority: Wallet;
+let taker: Wallet;
+let makerA: Wallet;
+
+let rfqCount: number;
+
+anchor.setProvider(anchor.AnchorProvider.env());
+
+const provider = anchor.getProvider();
+let program: Program;
+
+describe("RFQ Specification", () => {
+  before(async () => {
+    program = await getProgram(provider);
+
+    mintAuthority = new Wallet(Keypair.generate());
+    taker = new Wallet(Keypair.generate());
+    makerA = new Wallet(Keypair.generate());
+
+    await requestAirdrop(provider, mintAuthority.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, taker.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, makerA.publicKey, LAMPORTS_PER_SOL * 10);
+
+    const takerBalance = await provider.connection.getBalance(taker.publicKey);
+    console.log("Taker SOL balance:", takerBalance);
+
+    const mintAuthorityBalance = await provider.connection.getBalance(mintAuthority.publicKey);
+    console.log("Mint authority SOL balance:", mintAuthorityBalance);
+
+    assetToken = await Token.createMint(
+      program.provider.connection,
+      mintAuthority.payer,
+      mintAuthority.publicKey,
+      mintAuthority.publicKey,
+      ASSET_DECIMALS,
+      TOKEN_PROGRAM_ID
+    );
+    quoteToken = await Token.createMint(
+      program.provider.connection,
+      mintAuthority.payer,
+      mintAuthority.publicKey,
+      mintAuthority.publicKey,
+      QUOTE_DECIMALS,
+      TOKEN_PROGRAM_ID
+    );
+
+    takerAssetATA = await assetToken.createAssociatedTokenAccount(taker.publicKey);
+    makerAAssetATA = await assetToken.createAssociatedTokenAccount(makerA.publicKey);
+
+    takerQuoteATA = await quoteToken.createAssociatedTokenAccount(taker.publicKey);
+    makerAQuoteATA = await quoteToken.createAssociatedTokenAccount(makerA.publicKey);
+
+    await assetToken.mintTo(takerAssetATA, mintAuthority.publicKey, [], MINT_AIRDROP_ASSET);
+    await assetToken.mintTo(makerAAssetATA, mintAuthority.publicKey, [], MINT_AIRDROP_ASSET);
+
+    await quoteToken.mintTo(takerQuoteATA, mintAuthority.publicKey, [], MINT_AIRDROP_QUOTE);
+    await quoteToken.mintTo(makerAQuoteATA, mintAuthority.publicKey, [], MINT_AIRDROP_QUOTE);
+  });
+
+  it(`RFQ 1: Taker requests sell for PsyOptions American multi-leg strategy`, async () => {
+    const requestOrder = Order.Sell;
+    const now = new Date().getTime() / 1_000;
+    const expiry = now + 2;
+    const legs = [
+      {
+        // TODO: Is this correct?
+        amount: new anchor.BN(10),
+        contract: Contract.Call,
+        contractAssetAmount: new BN(1 * 10 ** ASSET_DECIMALS),
+        contractQuoteAmount: new BN(1 * 10 ** QUOTE_DECIMALS),
+        expiry: new BN(now + 30),
+        instrument: Instrument.Option,
+        venue: Venue.PsyOptions,
+        buySell: BuySell.Buy,
+      },
+      {
+        amount: new BN(5 * 10 ** ASSET_DECIMALS),
+        contract: null,
+        contractAssetAmount: null,
+        contractQuoteAmount: null,
+        expiry: null,
+        instrument: Instrument.Spot,
+        venue: Venue.Convergence,
+        buySell: BuySell.Buy,
+      },
+    ];
+
+    const res1 = await request(
+      null,
+      assetToken.publicKey,
+      taker,
+      expiry,
+      false,
+      legs,
+      TAKER_ORDER_AMOUNT2,
+      provider,
+      quoteToken.publicKey,
+      requestOrder
+    );
+    assert.equal(legs.toString(), res1.rfqState.legs.toString());
+
+    const res2 = await respond(
+      provider,
+      makerA,
+      res1.rfqPda,
+      MAKER_A_BID_AMOUNT1,
+      MAKER_A_ASK_AMOUNT1,
+      makerAAssetATA,
+      makerAQuoteATA
+    );
+
+    await confirm(provider, res1.rfqPda, res2.orderPda, taker, takerAssetATA, takerQuoteATA, Quote.Bid);
+    await settle(provider, taker, res1.rfqPda, res2.orderPda, takerAssetATA, takerQuoteATA);
+    await settle(provider, makerA, res1.rfqPda, res2.orderPda, makerAAssetATA, makerAQuoteATA);
+
+    await processLegs(provider, res1.rfqPda, taker);
+
+    const rfqState: any = await program.account.rfqState.fetch(res1.rfqPda);
+    for (let i = 0; i < rfqState.legs.length; i++) {
+      assert.ok(rfqState.legs[i].processed);
+    }
+  });
+});

--- a/tests/integration/rfq.spec.ts
+++ b/tests/integration/rfq.spec.ts
@@ -1,0 +1,816 @@
+/**
+ * RFQ Specification
+ *
+ * Step 1 - Requests:
+ * - Taker wants an asset quote for one or two-way market
+ *
+ * Optional - Cancels:
+ * - Taker cancels RFQ
+ *
+ * Step 2: Responds:
+ * - Maker submits one or two-way order and deposits collateral
+ *
+ * Step 3 - Confirms:
+ * - Taker confirms response by depositing collateral
+ *
+ * Optional - Last look:
+ * - Set to false
+ *
+ * Step 4 - Returns collateral:
+ * - Unconfirmed maker orders get collateral returned
+ *
+ * Step 5 - Settles:
+ * - Taker receives quote
+ * - Maker receives asset
+ */
+
+import * as anchor from "@project-serum/anchor";
+import { Wallet } from "@project-serum/anchor";
+import { Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { Keypair, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import * as assert from "assert";
+
+import {
+  Instrument,
+  Order,
+  Quote,
+  Venue,
+  calcFee,
+  cancel,
+  confirm,
+  getBalance,
+  getRFQs,
+  getProgram,
+  getAllOrders,
+  getMyOrders,
+  getRfqOrders,
+  initializeProtocol,
+  lastLook,
+  respond,
+  returnCollateral,
+  request,
+  requestAirdrop,
+  setFee,
+  settle,
+} from "../../lib/helpers";
+import { Program } from "@project-serum/anchor";
+
+let assetToken: Token;
+let quoteToken: Token;
+
+const ASSET_DECIMALS = 6;
+const QUOTE_DECIMALS = 2;
+
+const MINT_AIRDROP_ASSET = 1_000_000 * 10 ** ASSET_DECIMALS;
+const MINT_AIRDROP_QUOTE = 10_000_000_000_000 * 10 ** QUOTE_DECIMALS;
+
+const FEE_NUMERATOR = 1;
+const FEE_DENOMINATOR = 1_000;
+
+const TAKER_ORDER_AMOUNT1 = 5 * 10 ** ASSET_DECIMALS;
+const TAKER_ORDER_AMOUNT2 = 32 * 10 ** ASSET_DECIMALS;
+const TAKER_ORDER_AMOUNT3 = 20 * 10 ** ASSET_DECIMALS;
+const TAKER_ORDER_AMOUNT4 = 17 * 10 ** ASSET_DECIMALS;
+
+const MAKER_A_ASK_AMOUNT1 = 41_000 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT1;
+const MAKER_A_BID_AMOUNT1 = 39_100 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT1;
+const MAKER_A_ASK_AMOUNT2 = 41_100 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT1;
+const MAKER_A_BID_AMOUNT2 = 39_200 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT1; // Sell winner
+const MAKER_B_ASK_AMOUNT1 = null;
+const MAKER_B_BID_AMOUNT1 = 40_000 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT2;
+const MAKER_B_ASK_AMOUNT2 = 42_000 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT2;
+const MAKER_B_BID_AMOUNT2 = 41_000 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT2; // Invalid
+const MAKER_C_ASK_AMOUNT1 = null;
+const MAKER_C_BID_AMOUNT1 = 41_100 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT2; // Sell winner
+const MAKER_C_ASK_AMOUNT2 = null;
+const MAKER_C_BID_AMOUNT2 = 39_000 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT2;
+const MAKER_D_ASK_AMOUNT1 = 39_500 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT2;
+const MAKER_D_BID_AMOUNT1 = null;
+const MAKER_D_ASK_AMOUNT2 = 39_000 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT3; // Buy winner
+const MAKER_D_BID_AMOUNT2 = null;
+const MAKER_D_ASK_AMOUNT3 = 39_100 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT4; // Expires
+const MAKER_D_BID_AMOUNT3 = 39_010 * 10 ** QUOTE_DECIMALS * TAKER_ORDER_AMOUNT4;
+
+const FEE1 = calcFee(MAKER_A_BID_AMOUNT2, FEE_NUMERATOR, FEE_DENOMINATOR);
+const FEE2 = calcFee(MAKER_C_BID_AMOUNT1, FEE_NUMERATOR, FEE_DENOMINATOR);
+const FEE3 = calcFee(TAKER_ORDER_AMOUNT3, FEE_NUMERATOR, FEE_DENOMINATOR);
+
+let daoAssetATA: PublicKey;
+let daoQuoteATA: PublicKey;
+let takerAssetATA: PublicKey;
+let takerQuoteATA: PublicKey;
+let makerAAssetATA: PublicKey;
+let makerAQuoteATA: PublicKey;
+let makerBAssetATA: PublicKey;
+let makerBQuoteATA: PublicKey;
+let makerCAssetATA: PublicKey;
+let makerCQuoteATA: PublicKey;
+let makerDAssetATA: PublicKey;
+let makerDQuoteATA: PublicKey;
+
+let mintAuthority: Wallet;
+let dao: Wallet;
+let bot: Wallet;
+let taker: Wallet;
+let makerA: Wallet;
+let makerB: Wallet;
+let makerC: Wallet;
+let makerD: Wallet;
+
+let rfqPda: PublicKey;
+
+let orderPda1: PublicKey;
+let orderPda2: PublicKey;
+let orderPda3: PublicKey;
+
+anchor.setProvider(anchor.AnchorProvider.env());
+
+const provider = anchor.getProvider();
+let program: Program;
+
+const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+describe("RFQ Specification", () => {
+  before(async () => {
+    program = await getProgram(provider);
+
+    mintAuthority = new Wallet(Keypair.generate());
+    dao = new Wallet(Keypair.generate());
+    taker = new Wallet(Keypair.generate());
+    bot = new Wallet(Keypair.generate());
+    makerA = new Wallet(Keypair.generate());
+    makerB = new Wallet(Keypair.generate());
+    makerC = new Wallet(Keypair.generate());
+    makerD = new Wallet(Keypair.generate());
+
+    await requestAirdrop(provider, mintAuthority.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, dao.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, taker.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, bot.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, makerA.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, makerB.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, makerC.publicKey, LAMPORTS_PER_SOL * 10);
+    await requestAirdrop(provider, makerD.publicKey, LAMPORTS_PER_SOL * 10);
+
+    const takerBalance = await provider.connection.getBalance(taker.publicKey);
+    console.log("Taker SOL balance:", takerBalance);
+
+    const mintAuthorityBalance = await provider.connection.getBalance(mintAuthority.publicKey);
+    console.log("Mint authority SOL balance:", mintAuthorityBalance);
+
+    assetToken = await Token.createMint(
+      program.provider.connection,
+      mintAuthority.payer,
+      mintAuthority.publicKey,
+      mintAuthority.publicKey,
+      ASSET_DECIMALS,
+      TOKEN_PROGRAM_ID
+    );
+    quoteToken = await Token.createMint(
+      program.provider.connection,
+      mintAuthority.payer,
+      mintAuthority.publicKey,
+      mintAuthority.publicKey,
+      QUOTE_DECIMALS,
+      TOKEN_PROGRAM_ID
+    );
+
+    // NOTE: Do not create DAO asset ATA as this is tested for in settle function
+    takerAssetATA = await assetToken.createAssociatedTokenAccount(taker.publicKey);
+    makerAAssetATA = await assetToken.createAssociatedTokenAccount(makerA.publicKey);
+    makerBAssetATA = await assetToken.createAssociatedTokenAccount(makerB.publicKey);
+    makerCAssetATA = await assetToken.createAssociatedTokenAccount(makerC.publicKey);
+    makerDAssetATA = await assetToken.createAssociatedTokenAccount(makerD.publicKey);
+
+    daoQuoteATA = await quoteToken.createAssociatedTokenAccount(dao.publicKey);
+    takerQuoteATA = await quoteToken.createAssociatedTokenAccount(taker.publicKey);
+    makerAQuoteATA = await quoteToken.createAssociatedTokenAccount(makerA.publicKey);
+    makerBQuoteATA = await quoteToken.createAssociatedTokenAccount(makerB.publicKey);
+    makerCQuoteATA = await quoteToken.createAssociatedTokenAccount(makerC.publicKey);
+    makerDQuoteATA = await quoteToken.createAssociatedTokenAccount(makerD.publicKey);
+
+    await assetToken.mintTo(takerAssetATA, mintAuthority.publicKey, [], MINT_AIRDROP_ASSET);
+    await assetToken.mintTo(makerAAssetATA, mintAuthority.publicKey, [], MINT_AIRDROP_ASSET);
+    await assetToken.mintTo(makerBAssetATA, mintAuthority.publicKey, [], MINT_AIRDROP_ASSET);
+    await assetToken.mintTo(makerCAssetATA, mintAuthority.publicKey, [], MINT_AIRDROP_ASSET);
+    await assetToken.mintTo(makerDAssetATA, mintAuthority.publicKey, [], MINT_AIRDROP_ASSET);
+
+    await quoteToken.mintTo(takerQuoteATA, mintAuthority.publicKey, [], MINT_AIRDROP_QUOTE);
+    await quoteToken.mintTo(makerAQuoteATA, mintAuthority.publicKey, [], MINT_AIRDROP_QUOTE);
+    await quoteToken.mintTo(makerBQuoteATA, mintAuthority.publicKey, [], MINT_AIRDROP_QUOTE);
+    await quoteToken.mintTo(makerCQuoteATA, mintAuthority.publicKey, [], MINT_AIRDROP_QUOTE);
+    await quoteToken.mintTo(makerDQuoteATA, mintAuthority.publicKey, [], MINT_AIRDROP_QUOTE);
+  });
+
+  it("DAO initializes protocol with 0bps fee", async () => {
+    const { protocolState } = await initializeProtocol(provider, dao, FEE_DENOMINATOR, 0);
+    assert.ok(protocolState.feeDenominator.eq(new anchor.BN(FEE_DENOMINATOR)));
+    assert.ok(protocolState.feeNumerator.eq(new anchor.BN(0)));
+  });
+
+  it(`DAO sets ${FEE_NUMERATOR}bps protocol fee`, async () => {
+    const { protocolState } = await setFee(provider, dao, FEE_DENOMINATOR, FEE_NUMERATOR);
+    assert.ok(protocolState.feeDenominator.eq(new anchor.BN(FEE_DENOMINATOR)));
+    assert.ok(protocolState.feeNumerator.eq(new anchor.BN(FEE_NUMERATOR)));
+  });
+
+  it(`RFQ 1: Taker requests two-way asset quote for ${TAKER_ORDER_AMOUNT1}`, async () => {
+    const requestOrder = Order.TwoWay;
+    const now = new Date().getTime() / 1_000;
+    const expiry = now + 2; // Expires in 2 seconds
+    const legs = [
+      {
+        amount: new anchor.BN(TAKER_ORDER_AMOUNT1),
+        instrument: Instrument.Spot,
+        venue: Venue.Convergence,
+      },
+    ];
+
+    const res = await request(
+      null,
+      assetToken.publicKey,
+      taker,
+      expiry,
+      false,
+      legs,
+      TAKER_ORDER_AMOUNT1,
+      provider,
+      quoteToken.publicKey,
+      requestOrder
+    );
+    assert.ok(res.rfqState.authority.toString() === taker.publicKey.toString());
+
+    rfqPda = res.rfqPda;
+  });
+
+  it("RFQ 1: Maker A responds to two-way request then Taker confirms best bid", async () => {
+    const res1 = await respond(
+      provider,
+      makerA,
+      rfqPda,
+      MAKER_A_BID_AMOUNT1,
+      MAKER_A_ASK_AMOUNT1,
+      makerAAssetATA,
+      makerAQuoteATA
+    );
+    orderPda1 = res1.orderPda;
+
+    const res2 = await respond(
+      provider,
+      makerA,
+      rfqPda,
+      MAKER_A_BID_AMOUNT2,
+      MAKER_A_ASK_AMOUNT2,
+      makerAAssetATA,
+      makerAQuoteATA
+    );
+    orderPda2 = res2.orderPda;
+
+    let assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+
+    try {
+      await confirm(provider, rfqPda, res1.orderPda, taker, takerAssetATA, takerQuoteATA, Quote.Bid);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "InvalidConfirm");
+    }
+
+    const { rfqState, orderState } = await confirm(
+      provider,
+      rfqPda,
+      res2.orderPda,
+      taker,
+      takerAssetATA,
+      takerQuoteATA,
+      Quote.Bid
+    );
+    console.log("Order confirmed quote:", orderState.confirmedQuote);
+    console.log("Best ask:", rfqState.bestAskAmount?.toNumber());
+    console.log("Best bid:", rfqState.bestBidAmount?.toNumber());
+
+    try {
+      await confirm(provider, rfqPda, res1.orderPda, taker, takerAssetATA, takerQuoteATA, Quote.Bid);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "RfqConfirmed");
+    }
+
+    try {
+      await respond(provider, makerA, rfqPda, MAKER_B_BID_AMOUNT1, MAKER_B_ASK_AMOUNT1, makerAAssetATA, makerAQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "RfqConfirmed");
+    }
+
+    assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT1);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE);
+
+    assetBalance = await getBalance(provider, makerA.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerA.publicKey, quoteToken.publicKey);
+    console.log("Maker A asset balance:", assetBalance);
+    console.log("Maker A quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT1 - TAKER_ORDER_AMOUNT1);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE - MAKER_A_BID_AMOUNT1 - MAKER_A_BID_AMOUNT2);
+
+    assert.equal(rfqState.confirmed, true);
+  });
+
+  it("RFQ 1: Taker and Maker A return collateral then settle", async () => {
+    await returnCollateral(provider, makerA, rfqPda, orderPda1, makerAAssetATA, makerAQuoteATA);
+    await returnCollateral(provider, makerA, rfqPda, orderPda2, makerAAssetATA, makerAQuoteATA);
+    let assetBalance = await getBalance(provider, makerA.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, makerA.publicKey, quoteToken.publicKey);
+    console.log("Maker A asset balance:", assetBalance);
+    console.log("Maker A quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE - MAKER_A_BID_AMOUNT2);
+
+    await settle(provider, makerA, rfqPda, orderPda2, makerAAssetATA, makerAQuoteATA);
+    assetBalance = await getBalance(provider, makerA.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerA.publicKey, quoteToken.publicKey);
+    console.log("Maker A asset balance:", assetBalance);
+    console.log("Maker A quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET + TAKER_ORDER_AMOUNT1);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE - MAKER_A_BID_AMOUNT2);
+
+    await settle(provider, taker, rfqPda, orderPda2, takerAssetATA, takerQuoteATA);
+    assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT1);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE + MAKER_A_BID_AMOUNT2 - FEE1);
+  });
+
+  it("RFQ 2: Taker initializes sell for 10", async () => {
+    const orderType = Order.Sell;
+    const now = new Date().getTime() / 1_000;
+    const expiry = now + 15; // Expires in 15 seconds
+    const orderAmount = TAKER_ORDER_AMOUNT2;
+    const legs = [
+      {
+        venue: Venue.Convergence,
+        amount: new anchor.BN(TAKER_ORDER_AMOUNT2),
+        instrument: Instrument.Spot,
+      },
+    ];
+
+    const res = await request(
+      null,
+      assetToken.publicKey,
+      taker,
+      expiry,
+      true,
+      legs,
+      orderAmount,
+      provider,
+      quoteToken.publicKey,
+      orderType
+    );
+    console.log("Order type:", res.rfqState.orderType);
+    console.log("Order amount:", res.rfqState.orderAmount.toNumber());
+
+    const assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    const quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+
+    assert.ok(res.rfqState.authority.toString() === taker.publicKey.toString());
+    assert.deepEqual(res.rfqState.orderType, orderType);
+    assert.equal(res.rfqState.orderAmount.toString(), TAKER_ORDER_AMOUNT2.toString());
+    assert.equal(res.rfqState.expiry.toString(), Math.floor(expiry).toString());
+
+    rfqPda = res.rfqPda;
+  });
+
+  it("RFQ 2: Maker B and C responds", async () => {
+    const res1 = await respond(
+      provider,
+      makerB,
+      rfqPda,
+      MAKER_B_BID_AMOUNT1,
+      MAKER_B_ASK_AMOUNT1,
+      makerBAssetATA,
+      makerBQuoteATA
+    );
+    console.log("Response 1 best ask:", res1.rfqState.bestAskAmount?.toNumber());
+    console.log("Response 1 best bid:", res1.rfqState.bestBidAmount?.toNumber());
+
+    orderPda1 = res1.orderPda;
+
+    try {
+      await respond(provider, makerB, rfqPda, MAKER_B_BID_AMOUNT2, MAKER_B_ASK_AMOUNT2, makerBAssetATA, makerBQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "InvalidQuote");
+    }
+
+    const res2 = await respond(
+      provider,
+      makerC,
+      rfqPda,
+      MAKER_C_BID_AMOUNT1,
+      MAKER_C_ASK_AMOUNT1,
+      makerCAssetATA,
+      makerCQuoteATA
+    );
+    console.log("Response 2 best ask:", res2.rfqState.bestAskAmount?.toNumber());
+    console.log("Response 2 best bid:", res2.rfqState.bestBidAmount?.toNumber());
+
+    orderPda2 = res2.orderPda;
+
+    const res3 = await respond(
+      provider,
+      makerC,
+      rfqPda,
+      MAKER_C_BID_AMOUNT2,
+      MAKER_C_ASK_AMOUNT2,
+      makerCAssetATA,
+      makerCQuoteATA
+    );
+    console.log("Response 3 best ask:", res3.rfqState.bestAskAmount?.toNumber());
+    console.log("Response 3 best bid:", res3.rfqState.bestBidAmount?.toNumber());
+
+    orderPda3 = res3.orderPda;
+
+    let assetBalance = await getBalance(provider, makerB.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, makerB.publicKey, quoteToken.publicKey);
+    console.log("Maker B asset balance:", assetBalance);
+    console.log("Maker B quote balance:", quoteBalance);
+
+    assetBalance = await getBalance(provider, makerC.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerC.publicKey, quoteToken.publicKey);
+    console.log("Maker C asset balance:", assetBalance);
+    console.log("Maker C quote balance:", quoteBalance);
+
+    assert.equal(res1.rfqState.bestBidAmount?.toString(), MAKER_B_BID_AMOUNT1.toString());
+    assert.equal(res2.rfqState.bestBidAmount?.toString(), MAKER_C_BID_AMOUNT1.toString());
+    assert.equal(res3.rfqState.bestBidAmount?.toString(), MAKER_C_BID_AMOUNT1.toString());
+  });
+
+  it("RFQ 2: Taker confirms Maker B bid for 410,000", async () => {
+    try {
+      await confirm(provider, rfqPda, orderPda1, taker, takerAssetATA, takerQuoteATA, Quote.Bid);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "InvalidConfirm");
+    }
+
+    try {
+      await confirm(provider, rfqPda, orderPda2, taker, takerAssetATA, takerQuoteATA, Quote.Ask);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "InvalidConfirm");
+    }
+
+    const { rfqState } = await confirm(provider, rfqPda, orderPda2, taker, takerAssetATA, takerQuoteATA, Quote.Bid);
+    console.log("Best ask:", rfqState.bestAskAmount?.toNumber());
+    console.log("Best bid:", rfqState.bestBidAmount?.toNumber());
+
+    let assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT2 - TAKER_ORDER_AMOUNT1);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE + MAKER_A_BID_AMOUNT2 - FEE1);
+    assert.equal(rfqState.confirmed, true);
+  });
+
+  it("RFQ 2: Maker B and C last looks", async () => {
+    const res1 = await lastLook(provider, makerB, rfqPda, orderPda1);
+    const res2 = await lastLook(provider, makerC, rfqPda, orderPda2);
+    const res3 = await lastLook(provider, makerC, rfqPda, orderPda3);
+
+    console.log("Order type:", res2.rfqState.orderType);
+    console.log("Last look:", res3.rfqState.lastLook);
+
+    assert.equal(res1.rfqState.approved, true);
+  });
+
+  it("RFQ 2: Maker B and C return collateral", async () => {
+    await returnCollateral(provider, makerB, rfqPda, orderPda1, makerBAssetATA, makerBQuoteATA);
+    await returnCollateral(provider, makerC, rfqPda, orderPda3, makerCAssetATA, makerCQuoteATA);
+
+    try {
+      await returnCollateral(provider, makerC, rfqPda, orderPda2, makerCAssetATA, makerCQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "OrderConfirmed");
+    }
+
+    try {
+      await returnCollateral(provider, makerC, rfqPda, orderPda3, makerCAssetATA, makerCQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "CollateralReturned");
+    }
+
+    let assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+
+    assetBalance = await getBalance(provider, makerA.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerA.publicKey, quoteToken.publicKey);
+    console.log("Maker A asset balance:", assetBalance);
+    console.log("Maker A quote balance:", quoteBalance);
+
+    assetBalance = await getBalance(provider, makerB.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerB.publicKey, quoteToken.publicKey);
+    console.log("Maker B asset balance:", assetBalance);
+    console.log("Maker B quote balance:", quoteBalance);
+
+    assetBalance = await getBalance(provider, makerC.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerC.publicKey, quoteToken.publicKey);
+    console.log("Maker C asset balance:", assetBalance);
+    console.log("Maker C quote balance:", quoteBalance);
+  });
+
+  it("RFQ 2: Taker and Maker B settle", async () => {
+    await settle(provider, taker, rfqPda, orderPda2, takerAssetATA, takerQuoteATA);
+
+    try {
+      await settle(provider, makerB, rfqPda, orderPda2, makerBAssetATA, makerBQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "InvalidAuthority");
+    }
+
+    await settle(provider, makerC, rfqPda, orderPda2, makerCAssetATA, makerCQuoteATA);
+
+    try {
+      await settle(provider, makerC, rfqPda, orderPda2, makerCAssetATA, makerCQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "OrderSettled");
+    }
+
+    try {
+      await settle(provider, taker, rfqPda, orderPda2, takerAssetATA, takerQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "RfqSettled");
+    }
+
+    let assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT2 - TAKER_ORDER_AMOUNT1);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE + MAKER_A_BID_AMOUNT2 - FEE1 + MAKER_C_BID_AMOUNT1 - FEE2);
+
+    assetBalance = await getBalance(provider, makerB.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerB.publicKey, quoteToken.publicKey);
+    console.log("Maker B asset balance:", assetBalance);
+    console.log("Maker B quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE);
+
+    assetBalance = await getBalance(provider, makerC.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerC.publicKey, quoteToken.publicKey);
+    console.log("Maker C asset balance:", assetBalance);
+    console.log("Maker C quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET + TAKER_ORDER_AMOUNT2);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE - MAKER_C_BID_AMOUNT1);
+  });
+
+  it(`RFQ 3: Taker requests buy order for ${TAKER_ORDER_AMOUNT3}, Maker D responds, Taker confirms, both settle`, async () => {
+    const requestOrder = Order.Buy;
+    const now = new Date().getTime() / 1_000;
+    const expiry = now + 3;
+    const legs = [
+      {
+        amount: new anchor.BN(TAKER_ORDER_AMOUNT3),
+        instrument: Instrument.Spot,
+        venue: Venue.Convergence,
+      },
+    ];
+
+    const res = await request(
+      null,
+      assetToken.publicKey,
+      taker,
+      expiry,
+      false,
+      legs,
+      TAKER_ORDER_AMOUNT3,
+      provider,
+      quoteToken.publicKey,
+      requestOrder
+    );
+    rfqPda = res.rfqPda;
+
+    const res1 = await respond(
+      provider,
+      makerD,
+      rfqPda,
+      MAKER_D_BID_AMOUNT1,
+      MAKER_D_ASK_AMOUNT1,
+      makerDAssetATA,
+      makerDQuoteATA
+    );
+    const res2 = await respond(
+      provider,
+      makerD,
+      rfqPda,
+      MAKER_D_BID_AMOUNT2,
+      MAKER_D_ASK_AMOUNT2,
+      makerDAssetATA,
+      makerDQuoteATA
+    );
+    orderPda1 = res1.orderPda;
+    orderPda2 = res2.orderPda;
+
+    await confirm(provider, rfqPda, orderPda2, taker, takerAssetATA, takerQuoteATA, Quote.Ask);
+    await returnCollateral(provider, makerD, rfqPda, orderPda1, makerDAssetATA, makerDQuoteATA);
+    await settle(provider, taker, rfqPda, orderPda2, takerAssetATA, takerQuoteATA);
+    await settle(provider, makerD, rfqPda, orderPda2, makerDAssetATA, makerDQuoteATA);
+
+    let assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+    assert.equal(
+      assetBalance,
+      MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT2 - TAKER_ORDER_AMOUNT1 + TAKER_ORDER_AMOUNT3 - FEE3
+    );
+    assert.equal(
+      quoteBalance,
+      MINT_AIRDROP_QUOTE + MAKER_A_BID_AMOUNT2 - FEE1 + MAKER_C_BID_AMOUNT1 - FEE2 - MAKER_D_ASK_AMOUNT2
+    );
+
+    assetBalance = await getBalance(provider, makerD.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerD.publicKey, quoteToken.publicKey);
+    console.log("Maker D asset balance:", assetBalance);
+    console.log("Maker D quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT3);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE + MAKER_D_ASK_AMOUNT2);
+  });
+
+  it(`RFQ 4: Taker requests two-way for ${TAKER_ORDER_AMOUNT4} but response expires and collateral is returned`, async () => {
+    const requestOrder = Order.TwoWay;
+    const now = new Date().getTime() / 1_000;
+    const expiry = now + 1;
+    const legs = [
+      {
+        amount: new anchor.BN(TAKER_ORDER_AMOUNT4),
+        instrument: Instrument.Spot,
+        venue: Venue.Convergence,
+      },
+    ];
+
+    const res = await request(
+      null,
+      assetToken.publicKey,
+      taker,
+      expiry,
+      false,
+      legs,
+      TAKER_ORDER_AMOUNT4,
+      provider,
+      quoteToken.publicKey,
+      requestOrder
+    );
+    rfqPda = res.rfqPda;
+
+    let assetBalance = await getBalance(provider, makerD.publicKey, assetToken.publicKey);
+    let quoteBalance = await getBalance(provider, makerD.publicKey, quoteToken.publicKey);
+    console.log("Maker D asset balance:", assetBalance);
+    console.log("Maker D quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT3);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE + MAKER_D_ASK_AMOUNT2);
+
+    const res1 = await respond(
+      provider,
+      makerD,
+      rfqPda,
+      MAKER_D_BID_AMOUNT3,
+      MAKER_D_ASK_AMOUNT3,
+      makerDAssetATA,
+      makerDQuoteATA
+    );
+    console.log("Order bid:", res1.orderState.bid.toNumber());
+    console.log("Order ask:", res1.orderState.ask.toNumber());
+    assert.ok(!res1.rfqState.settled);
+    orderPda1 = res1.orderPda;
+
+    console.log("Sleeping for 2s...");
+    await sleep(3_000);
+
+    try {
+      await respond(provider, makerD, rfqPda, MAKER_D_BID_AMOUNT2, MAKER_D_ASK_AMOUNT2, makerDAssetATA, makerDQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "RfqInactive");
+    }
+
+    try {
+      await confirm(provider, rfqPda, orderPda1, taker, takerAssetATA, takerQuoteATA, Quote.Ask);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "RfqInactive");
+    }
+
+    try {
+      await settle(provider, taker, rfqPda, orderPda1, takerAssetATA, takerQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "RfqUnconfirmed");
+    }
+
+    assetBalance = await getBalance(provider, makerD.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerD.publicKey, quoteToken.publicKey);
+    console.log("Maker D asset balance:", assetBalance);
+    console.log("Maker D quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT3 - TAKER_ORDER_AMOUNT4);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE + MAKER_D_ASK_AMOUNT2 - MAKER_D_BID_AMOUNT3);
+
+    const res2 = await returnCollateral(provider, makerD, rfqPda, orderPda1, makerDAssetATA, makerDQuoteATA);
+    console.log("Bid confirmed:", res2.orderState.bidConfirmed);
+    console.log("Ask confirmed:", res2.orderState.askConfirmed);
+    assert.ok(!res2.rfqState.confirmed);
+    assert.ok(!res2.orderState.askConfirmed);
+    assert.ok(!res2.orderState.bidConfirmed);
+
+    assetBalance = await getBalance(provider, makerD.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, makerD.publicKey, quoteToken.publicKey);
+    console.log("Maker D asset balance:", assetBalance);
+    console.log("Maker D quote balance:", quoteBalance);
+    assert.equal(assetBalance, MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT3);
+    assert.equal(quoteBalance, MINT_AIRDROP_QUOTE + MAKER_D_ASK_AMOUNT2);
+
+    assetBalance = await getBalance(provider, taker.publicKey, assetToken.publicKey);
+    quoteBalance = await getBalance(provider, taker.publicKey, quoteToken.publicKey);
+    console.log("Taker asset balance:", assetBalance);
+    console.log("Taker quote balance:", quoteBalance);
+    assert.equal(
+      assetBalance,
+      MINT_AIRDROP_ASSET - TAKER_ORDER_AMOUNT2 - TAKER_ORDER_AMOUNT1 + TAKER_ORDER_AMOUNT3 - FEE3
+    );
+    assert.equal(
+      quoteBalance,
+      MINT_AIRDROP_QUOTE + MAKER_A_BID_AMOUNT2 - FEE1 + MAKER_C_BID_AMOUNT1 - FEE2 - MAKER_D_ASK_AMOUNT2
+    );
+
+    const rfqOrders = await getRfqOrders(provider, rfqPda);
+    assert.equal(rfqOrders.length, 1);
+
+    const myOrders = await getMyOrders(provider, makerD.publicKey);
+    assert.equal(myOrders.length, 3);
+  });
+
+  it(`RFQ 5: Taker requests buy for ${TAKER_ORDER_AMOUNT2} but cancels`, async () => {
+    const requestOrder = Order.Buy;
+    const now = new Date().getTime() / 1_000;
+    const expiry = now + 2;
+    const legs = [
+      {
+        amount: new anchor.BN(TAKER_ORDER_AMOUNT2),
+        instrument: Instrument.Spot,
+        venue: Venue.Convergence,
+      },
+    ];
+
+    const res1 = await request(
+      null,
+      assetToken.publicKey,
+      taker,
+      expiry,
+      false,
+      legs,
+      TAKER_ORDER_AMOUNT2,
+      provider,
+      quoteToken.publicKey,
+      requestOrder
+    );
+    assert.ok(!res1.rfqState.canceled);
+
+    rfqPda = res1.rfqPda;
+
+    const res2 = await cancel(provider, taker, rfqPda);
+    assert.ok(res2.rfqState.canceled);
+
+    try {
+      await respond(provider, makerD, rfqPda, MAKER_D_BID_AMOUNT3, MAKER_D_ASK_AMOUNT3, makerDAssetATA, makerDQuoteATA);
+      assert.ok(false);
+    } catch (err) {
+      assert.strictEqual(err.error.errorCode.code, "RfqCanceled");
+    }
+  });
+
+  it("DAO views all RFQs and responses", async () => {
+    const rfqs: any = await getRFQs(provider, 1, 10);
+    const allOrders = await getAllOrders(provider);
+    assert.equal(rfqs.length, 5);
+    assert.equal(allOrders.length, 8);
+  });
+});

--- a/tests/unit/Test.toml
+++ b/tests/unit/Test.toml
@@ -1,0 +1,2 @@
+[scripts]
+test = "yarn run ts-mocha -t 1000000 -p ./tsconfig.json tests/unit/*.ts"

--- a/tests/unit/returnCollateral.spec.ts
+++ b/tests/unit/returnCollateral.spec.ts
@@ -1,0 +1,75 @@
+import { PublicKey } from "@saberhq/solana-contrib";
+import * as assert from "assert";
+import { Quote } from "../../lib/helpers";
+import { Context } from "../utilities/wrappers";
+import { DEFAULT_ASK_AMOUNT, DEFAULT_BID_AMOUNT, DEFAULT_TOKEN_AMOUNT } from "../utilities/constants";
+import { expectError, getTimestampInFuture, sleep } from "../utilities/helpers";
+
+describe("Return collateral", () => {
+  const context = new Context();
+  before(async () => {
+    await context.initialize();
+    await context.initializeProtocolIfNotInitialized();
+  });
+
+  const assertMakerTokens = async (makerKey: PublicKey, assets: number, quotes: number) => {
+    const makerAssets = await context.getAssetTokenBalance(makerKey);
+    assert.equal(makerAssets, assets);
+    const makerQuotes = await context.getQuoteTokenBalance(makerKey);
+    assert.equal(makerQuotes, quotes);
+  };
+
+  it("Successfully returns collateral from confirmed offer", async () => {
+    const rfq = await context.request();
+    const order = await rfq.respond();
+    await order.confirm({ quoteType: Quote.Bid });
+    await order.returnCollateral();
+    await assertMakerTokens(order.maker.publicKey, DEFAULT_TOKEN_AMOUNT, DEFAULT_TOKEN_AMOUNT - DEFAULT_BID_AMOUNT);
+  });
+
+  it("Successfully returns collateral after confirmation", async () => {
+    const rfq = await context.request();
+    const nonConfirmedOrder = await rfq.respond({
+      bidAmount: DEFAULT_BID_AMOUNT - 1,
+      askAmount: DEFAULT_ASK_AMOUNT + 1,
+    });
+    const order = await rfq.respond();
+    await order.confirm();
+    await nonConfirmedOrder.returnCollateral();
+    await assertMakerTokens(nonConfirmedOrder.maker.publicKey, DEFAULT_TOKEN_AMOUNT, DEFAULT_TOKEN_AMOUNT);
+  });
+
+  it("Can return after expiration", async () => {
+    const rfq = await context.request({ expiry: getTimestampInFuture(2) });
+    const order = await rfq.respond();
+    await sleep(2000);
+    await order.returnCollateral();
+    const state = await order.getState();
+    assert.ok(state.collateralReturned);
+  });
+
+  it("Can return after cancellation", async () => {
+    const rfq = await context.request();
+    const order = await rfq.respond();
+    await rfq.cancel();
+    await order.returnCollateral();
+    const state = await order.getState();
+    assert.ok(state.collateralReturned);
+  });
+
+  it("Can't return immediately after creation", async () => {
+    const rfq = await context.request();
+    const order = await rfq.respond();
+    const transaction = order.returnCollateral();
+    await expectError(transaction, "RfqActive");
+  });
+
+  it("Can't return twice", async () => {
+    const rfq = await context.request();
+    const order = await rfq.respond();
+    await order.confirm();
+    await order.returnCollateral();
+    const transaction = order.returnCollateral();
+    await expectError(transaction, "CollateralReturned");
+  });
+});

--- a/tests/utilities/constants.ts
+++ b/tests/utilities/constants.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_SOL_FOR_SIGNERS = 10_000 * 10 ** 9;
+export const FEE_NUMERATOR = 1;
+export const FEE_DENOMINATOR = 1_000;
+export const DEFAULT_ORDER_AMOUNT = 5 * 10 ** 9;
+export const DEFAULT_BID_AMOUNT = 80 * 10 ** 9;
+export const DEFAULT_ASK_AMOUNT = 100 * 10 ** 9;
+export const DEFAULT_TOKEN_AMOUNT = 1_000_000 * 10 ** 9;

--- a/tests/utilities/helpers.ts
+++ b/tests/utilities/helpers.ts
@@ -1,0 +1,26 @@
+// This function supresses solana error traces making test output clearer
+export const expectError = async (promise: Promise<any>, errorText: string) => {
+  // Disable error logs to prevent errors from blockchain validator spam
+  const cachedStderrWrite = process.stdout.write;
+  process.stderr.write = () => true;
+  try {
+    await promise;
+    throw new Error(`No error thrown!`);
+  } catch (e) {
+    // Restore error logs
+    process.stderr.write = cachedStderrWrite;
+
+    if (!e?.message.includes(errorText) && !e?.logs?.some((e: string) => e.includes(errorText))) {
+      throw e;
+    }
+  }
+};
+
+export const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+export function getTimestampInFuture(afterSeconds: number) {
+  const now = new Date().getTime() / 1_000;
+  return now + afterSeconds;
+}

--- a/tests/utilities/pdas.ts
+++ b/tests/utilities/pdas.ts
@@ -1,0 +1,55 @@
+import { BN } from "@project-serum/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { ASSET_ESCROW_SEED, ORDER_SEED, PROTOCOL_SEED, QUOTE_ESCROW_SEED, RFQ_SEED } from "../../lib/helpers";
+
+export async function getProtocolPda(programId: PublicKey) {
+  const [pda] = await PublicKey.findProgramAddress([Buffer.from(PROTOCOL_SEED)], programId);
+  return pda;
+}
+
+export async function getRfqPda(
+  programId: PublicKey,
+  taker: PublicKey,
+  assetMint: PublicKey,
+  quoteMint: PublicKey,
+  orderAmount: number,
+  expiry: number
+) {
+  const [pda] = await PublicKey.findProgramAddress(
+    [
+      Buffer.from(RFQ_SEED),
+      taker.toBuffer(),
+      assetMint.toBuffer(),
+      quoteMint.toBuffer(),
+      new BN(orderAmount).toArrayLike(Buffer, "le", 8),
+      new BN(expiry).toArrayLike(Buffer, "le", 8),
+    ],
+    programId
+  );
+
+  return pda;
+}
+
+export async function getAssetEscrowPda(programId: PublicKey, rfqPda: PublicKey) {
+  const [pda] = await PublicKey.findProgramAddress([Buffer.from(ASSET_ESCROW_SEED), rfqPda.toBuffer()], programId);
+  return pda;
+}
+
+export async function getQuoteEscrowPda(programId: PublicKey, rfqPda: PublicKey) {
+  const [pda] = await PublicKey.findProgramAddress([Buffer.from(QUOTE_ESCROW_SEED), rfqPda.toBuffer()], programId);
+  return pda;
+}
+
+export async function getOrderPda(programId: PublicKey, maker: PublicKey, rfqPda: PublicKey, bid: number, ask: number) {
+  const [pda] = await PublicKey.findProgramAddress(
+    [
+      Buffer.from(ORDER_SEED),
+      rfqPda.toBuffer(),
+      maker.toBuffer(),
+      new BN(bid ? bid : 0).toArrayLike(Buffer, "le", 8),
+      new BN(ask ? ask : 0).toArrayLike(Buffer, "le", 8),
+    ],
+    programId
+  );
+  return pda;
+}

--- a/tests/utilities/wrappers.ts
+++ b/tests/utilities/wrappers.ts
@@ -1,0 +1,292 @@
+import * as anchor from "@project-serum/anchor";
+import { BN } from "@project-serum/anchor";
+import { PublicKey, Keypair, SystemProgram, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
+import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID, Token } from "@solana/spl-token";
+import { Rfq as RfqIdl } from "../../target/types/rfq";
+import { Order as OrderType, Quote as QuoteType } from "../../lib/helpers";
+import { getTimestampInFuture } from "./helpers";
+import {
+  DEFAULT_ASK_AMOUNT,
+  DEFAULT_BID_AMOUNT,
+  DEFAULT_ORDER_AMOUNT,
+  DEFAULT_SOL_FOR_SIGNERS,
+  DEFAULT_TOKEN_AMOUNT,
+  FEE_DENOMINATOR,
+  FEE_NUMERATOR,
+} from "./constants";
+import { getAssetEscrowPda, getOrderPda, getProtocolPda, getQuoteEscrowPda, getRfqPda } from "./pdas";
+
+export class Context {
+  public program: anchor.Program<RfqIdl>;
+  public provider: anchor.Provider;
+  public taker: Keypair;
+  public assetToken: Token;
+  public quoteToken: Token;
+
+  constructor() {
+    this.provider = anchor.AnchorProvider.env();
+    anchor.setProvider(this.provider);
+    this.program = anchor.workspace.Rfq as anchor.Program<RfqIdl>;
+  }
+
+  async initialize() {
+    this.taker = await this.createPayer();
+    this.assetToken = await this.createMint();
+    this.quoteToken = await this.createMint();
+    await this.createTokenAccountsFor(this.taker.publicKey);
+  }
+
+  async createPayer() {
+    const payer = Keypair.generate();
+
+    await this.provider.connection.confirmTransaction(
+      await this.provider.connection.requestAirdrop(payer.publicKey, DEFAULT_SOL_FOR_SIGNERS),
+      "confirmed"
+    );
+
+    return payer;
+  }
+
+  async getAssetTokenAddress(address: PublicKey) {
+    return await Token.getAssociatedTokenAddress(
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      this.assetToken.publicKey,
+      address
+    );
+  }
+
+  async getAssetTokenBalance(address: PublicKey) {
+    const account = await this.assetToken.getAccountInfo(await this.getAssetTokenAddress(address));
+    return account.amount.toNumber();
+  }
+
+  async getQuoteTokenBalance(address: PublicKey) {
+    const account = await this.quoteToken.getAccountInfo(await this.getQuoteTokenAddress(address));
+    return account.amount.toNumber();
+  }
+
+  async getQuoteTokenAddress(address: PublicKey) {
+    return await Token.getAssociatedTokenAddress(
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      this.quoteToken.publicKey,
+      address
+    );
+  }
+
+  async createMint() {
+    return await Token.createMint(
+      this.provider.connection,
+      this.taker,
+      this.taker.publicKey,
+      null,
+      0,
+      TOKEN_PROGRAM_ID
+    );
+  }
+
+  async createPayerWithTokens() {
+    const payer = await this.createPayer();
+    await this.createTokenAccountsFor(payer.publicKey);
+
+    return payer;
+  }
+
+  async createTokenAccountsFor(address: PublicKey) {
+    await this.createAccountAndMintTokens(address, "asset");
+    await this.createAccountAndMintTokens(address, "quote");
+  }
+
+  async createAccountAndMintTokens(address: PublicKey, type: "asset" | "quote", amount?: number) {
+    let mint: Token;
+    if (type == "asset") {
+      mint = this.assetToken;
+    } else if (type == "quote") {
+      mint = this.quoteToken;
+    } else {
+      throw new Error("Unsuported type");
+    }
+
+    amount = amount ?? DEFAULT_TOKEN_AMOUNT;
+    const account = await mint.createAssociatedTokenAccount(address);
+    await mint.mintTo(account, this.taker, [], amount);
+  }
+
+  async initializeProtocolIfNotInitialized() {
+    const protocolPda = await getProtocolPda(this.program.programId);
+    1;
+    const currentProtocol = await this.program.account.protocolState.fetchNullable(protocolPda);
+    if (currentProtocol === null) {
+      await this.program.methods
+        .initialize(new anchor.BN(FEE_DENOMINATOR), new anchor.BN(FEE_NUMERATOR))
+        .accounts({
+          signer: this.taker.publicKey,
+          protocol: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([this.taker])
+        .rpc();
+    }
+  }
+
+  async request({
+    expiry = getTimestampInFuture(100),
+    lastLook = false,
+    legs = [],
+    orderAmount = DEFAULT_ORDER_AMOUNT,
+    orderType = OrderType.TwoWay,
+  } = {}) {
+    const protocolPda = await getProtocolPda(this.program.programId);
+    const rfqPda = await getRfqPda(
+      this.program.programId,
+      this.taker.publicKey,
+      this.assetToken.publicKey,
+      this.quoteToken.publicKey,
+      orderAmount,
+      expiry
+    );
+    const assetEscrow = await getAssetEscrowPda(this.program.programId, rfqPda);
+    const quoteEscrow = await getQuoteEscrowPda(this.program.programId, rfqPda);
+
+    await this.program.methods
+      .request(null, new BN(expiry), lastLook, legs, new BN(orderAmount), orderType)
+      .accounts({
+        assetEscrow,
+        assetMint: this.assetToken.publicKey,
+        signer: this.taker.publicKey,
+        protocol: protocolPda,
+        quoteEscrow,
+        quoteMint: this.quoteToken.publicKey,
+        rent: SYSVAR_RENT_PUBKEY,
+        rfq: rfqPda,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([this.taker])
+      .rpc();
+
+    return await Rfq.create(this, rfqPda);
+  }
+}
+
+export class Rfq {
+  public assetEscrow: PublicKey;
+  public quoteEscrow: PublicKey;
+
+  private constructor(public context: Context, public account: PublicKey) {}
+
+  static async create(context: Context, account: PublicKey) {
+    const result = new Rfq(context, account);
+    result.assetEscrow = await getAssetEscrowPda(context.program.programId, account);
+    result.quoteEscrow = await getQuoteEscrowPda(context.program.programId, account);
+    return result;
+  }
+
+  async respond({ maker = null, bidAmount = DEFAULT_BID_AMOUNT, askAmount = DEFAULT_ASK_AMOUNT } = {}) {
+    maker = maker ?? (await this.context.createPayerWithTokens());
+    const assetWallet = await this.context.getAssetTokenAddress(maker.publicKey);
+    const quoteWallet = await this.context.getQuoteTokenAddress(maker.publicKey);
+    const orderPda = await getOrderPda(
+      this.context.program.programId,
+      maker.publicKey,
+      this.account,
+      bidAmount,
+      askAmount
+    );
+
+    const tx = await this.context.program.methods
+      .respond(bidAmount ? new BN(bidAmount) : null, askAmount ? new BN(askAmount) : null)
+      .accounts({
+        assetMint: this.context.assetToken.publicKey,
+        assetWallet,
+        signer: maker.publicKey,
+        assetEscrow: this.assetEscrow,
+        quoteEscrow: this.quoteEscrow,
+        order: orderPda,
+        quoteMint: this.context.quoteToken.publicKey,
+        quoteWallet,
+        rent: SYSVAR_RENT_PUBKEY,
+        rfq: this.account,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([maker])
+      .rpc();
+
+    return new Order(this.context, this, maker, orderPda);
+  }
+
+  async cancel() {
+    const protocolPda = await getProtocolPda(this.context.program.programId);
+    await this.context.program.methods
+      .cancel()
+      .accounts({
+        signer: this.context.taker.publicKey,
+        protocol: protocolPda,
+        rfq: this.account,
+      })
+      .signers([this.context.taker])
+      .rpc();
+  }
+
+  async getState() {
+    return this.context.program.account.rfqState.fetch(this.account);
+  }
+}
+
+export class Order {
+  constructor(public context: Context, public rfq: Rfq, public maker: Keypair, public account: PublicKey) {}
+
+  async confirm({ quoteType = QuoteType.Bid } = {}) {
+    const takerAddress = this.context.taker.publicKey;
+    const assetWallet = await this.context.getAssetTokenAddress(takerAddress);
+    const quoteWallet = await this.context.getQuoteTokenAddress(takerAddress);
+
+    await this.context.program.methods
+      .confirm(quoteType)
+      .accounts({
+        assetMint: this.context.assetToken.publicKey,
+        assetWallet,
+        signer: this.context.taker.publicKey,
+        assetEscrow: this.rfq.assetEscrow,
+        order: this.account,
+        quoteWallet,
+        quoteEscrow: this.rfq.quoteEscrow,
+        quoteMint: this.context.quoteToken.publicKey,
+        rent: SYSVAR_RENT_PUBKEY,
+        rfq: this.rfq.account,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([this.context.taker])
+      .rpc();
+  }
+
+  async returnCollateral() {
+    const assetWallet = await this.context.getAssetTokenAddress(this.maker.publicKey);
+    const quoteWallet = await this.context.getQuoteTokenAddress(this.maker.publicKey);
+
+    await this.context.program.methods
+      .returnCollateral()
+      .accounts({
+        assetEscrow: this.rfq.assetEscrow,
+        assetMint: this.context.assetToken.publicKey,
+        assetWallet,
+        signer: this.maker.publicKey,
+        order: this.account,
+        quoteEscrow: this.rfq.quoteEscrow,
+        quoteWallet,
+        quoteMint: this.context.quoteToken.publicKey,
+        rent: SYSVAR_RENT_PUBKEY,
+        rfq: this.rfq.account,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([this.maker])
+      .rpc();
+  }
+
+  async getState() {
+    return this.context.program.account.orderState.fetch(this.account);
+  }
+}


### PR DESCRIPTION
This MR includes:
- Allow returning collateral after an RFQ is canceled
- Utilities for simplifying writing unit tests in the tests\utilities folder
- Some unit tests for a new and existing return collateral instruction logic(tests/unit/returnCollateral.spec.ts)
- Integration tests moved to a separate test case to avoid conflicts between already written tests and new ones
Unit tests currently take a lot of time to run, it's an area of potential improvement. I plan to expand test utilities in the future to allow testing of more negative cases(invalid accounts, mints, authorities, e.t.c.)