### PR TITLE
Rework for options to store decimals along the values

### DIFF
--- a/psyoptions-american-instrument/program/src/errors.rs
+++ b/psyoptions-american-instrument/program/src/errors.rs
@@ -14,10 +14,14 @@ pub enum PsyoptionsAmericanError {
     NotFirstToPrepare,
     #[msg("Passed metadata account does not match")]
     PassedAmericanMetaDoesNotMatch,
-    #[msg("Passed underlying ammount does not match")]
+    #[msg("Passed underlying amount per contract does not match")]
     PassedUnderlyingAmountPerContractDoesNotMatch,
+    #[msg("Passed underlying amount per contract decimals does not match")]
+    PassedUnderlyingAmountPerContractDecimalsDoesNotMatch,
     #[msg("Passed strike price does not match")]
     PassedStrikePriceDoesNotMatch,
+    #[msg("Passed strike price decimals does not match")]
+    PassedStrikePriceDecimalsDoesNotMatch,
     #[msg("Passed expiration timestamp does not match")]
     PassedExpirationTimestampDoesNotMatch,
     #[msg("Stablecoin as base asset is not supported")]

--- a/psyoptions-american-instrument/program/src/instructions.rs
+++ b/psyoptions-american-instrument/program/src/instructions.rs
@@ -16,6 +16,8 @@ pub struct ValidateData<'info> {
     pub american_meta: Account<'info, OptionMarket>,
     #[account(constraint = american_meta.underlying_asset_mint == mint_info.mint_address @ PsyoptionsAmericanError::PassedMintDoesNotMatch)]
     pub mint_info: Account<'info, MintInfo>,
+    #[account(constraint = american_meta.quote_asset_mint == quote_mint.mint_address @ PsyoptionsAmericanError::PassedMintDoesNotMatch)]
+    pub quote_mint: Account<'info, MintInfo>,
 }
 
 #[derive(Accounts)]

--- a/psyoptions-american-instrument/program/src/lib.rs
+++ b/psyoptions-american-instrument/program/src/lib.rs
@@ -28,6 +28,7 @@ pub mod psyoptions_american_instrument {
         let ValidateData {
             american_meta,
             mint_info,
+            quote_mint,
             ..
         } = &ctx.accounts;
 
@@ -55,9 +56,19 @@ pub mod psyoptions_american_instrument {
                 == american_meta.underlying_amount_per_contract,
             PsyoptionsAmericanError::PassedUnderlyingAmountPerContractDoesNotMatch
         );
+        require_eq!(
+            option_common_data.underlying_amound_per_contract_decimals,
+            mint_info.decimals,
+            PsyoptionsAmericanError::PassedUnderlyingAmountPerContractDoesNotMatch
+        );
         require!(
             option_common_data.strike_price == american_meta.quote_amount_per_contract,
             PsyoptionsAmericanError::PassedStrikePriceDoesNotMatch
+        );
+        require_eq!(
+            option_common_data.strike_price_decimals,
+            quote_mint.decimals,
+            PsyoptionsAmericanError::PassedStrikePriceDecimalsDoesNotMatch
         );
         require!(
             option_common_data.expiration_timestamp == american_meta.expiration_unix_timestamp,

--- a/psyoptions-european-instrument/program/src/errors.rs
+++ b/psyoptions-european-instrument/program/src/errors.rs
@@ -22,8 +22,12 @@ pub enum PsyoptionsEuropeanError {
     NotFirstToPrepare,
     #[msg("Passed underlying amount per contract does not match")]
     PassedUnderlyingAmountPerContractDoesNotMatch,
+    #[msg("Passed underlying amount per contract decimals does not match")]
+    PassedUnderlyingAmountPerContractDecimalsDoesNotMatch,
     #[msg("Passed strike price does not match")]
     PassedStrikePriceDoesNotMatch,
+    #[msg("Passed strike price decimals does not match")]
+    PassedStrikePriceDecimalsDoesNotMatch,
     #[msg("Passed expiration timestamp does not match")]
     PassedExpirationTimestampDoesNotMatch,
     #[msg("Stablecoin as base asset is not supported")]

--- a/psyoptions-european-instrument/program/src/lib.rs
+++ b/psyoptions-european-instrument/program/src/lib.rs
@@ -63,9 +63,19 @@ pub mod psyoptions_european_instrument {
                 == euro_meta.underlying_amount_per_contract,
             PsyoptionsEuropeanError::PassedUnderlyingAmountPerContractDoesNotMatch
         );
+        require_eq!(
+            option_common_data.underlying_amound_per_contract_decimals,
+            euro_meta.underlying_decimals,
+            PsyoptionsEuropeanError::PassedUnderlyingAmountPerContractDecimalsDoesNotMatch
+        );
         require!(
             option_common_data.strike_price == euro_meta.strike_price,
             PsyoptionsEuropeanError::PassedStrikePriceDoesNotMatch
+        );
+        require_eq!(
+            option_common_data.strike_price_decimals,
+            euro_meta.price_decimals,
+            PsyoptionsEuropeanError::PassedStrikePriceDecimalsDoesNotMatch
         );
         require!(
             option_common_data.expiration_timestamp == euro_meta.expiration,

--- a/risk-engine/program/src/risk_calculator.rs
+++ b/risk-engine/program/src/risk_calculator.rs
@@ -558,7 +558,9 @@ mod tests {
         let option_data = OptionCommonData {
             option_type: OptionType::Call,
             underlying_amount_per_contract: 1 * 10_u64.pow(8),
+            underlying_amound_per_contract_decimals: 9,
             strike_price: 22000 * 10_u64.pow(9),
+            strike_price_decimals: 9,
             expiration_timestamp: 90 * 24 * 60 * 60,
         };
 

--- a/risk-engine/program/src/state.rs
+++ b/risk-engine/program/src/state.rs
@@ -113,23 +113,23 @@ impl Default for InstrumentType {
 pub struct OptionCommonData {
     pub option_type: OptionType,
     pub underlying_amount_per_contract: u64,
+    pub underlying_amound_per_contract_decimals: u8,
     pub strike_price: u64,
+    pub strike_price_decimals: u8,
     pub expiration_timestamp: i64,
 }
 
 impl OptionCommonData {
-    pub const STRIKE_PRICE_DECIMALS: u8 = 9;
-    pub const UNDERLYING_AMOUNT_PER_CONTRACT_DECIMALS: u8 = 9;
-    pub const SERIALIZED_SIZE: usize = 1 + 8 + 8 + 8;
+    pub const SERIALIZED_SIZE: usize = 1 + 8 + 1 + 8 + 1 + 8;
 
     pub fn get_strike_price(&self) -> f64 {
-        convert_fixed_point_to_f64(self.strike_price.into(), Self::STRIKE_PRICE_DECIMALS)
+        convert_fixed_point_to_f64(self.strike_price.into(), self.strike_price_decimals)
     }
 
     pub fn get_underlying_amount_per_contract(&self) -> f64 {
         convert_fixed_point_to_f64(
             self.underlying_amount_per_contract.into(),
-            Self::UNDERLYING_AMOUNT_PER_CONTRACT_DECIMALS,
+            self.underlying_amound_per_contract_decimals,
         )
     }
 }
@@ -143,16 +143,16 @@ pub enum OptionType {
 #[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone)]
 pub struct FutureCommonData {
     pub underlying_amount_per_contract: u64,
+    pub underlying_amound_per_contract_decimals: u8,
 }
 
 impl FutureCommonData {
-    pub const UNDERLYING_AMOUNT_PER_CONTRACT_DECIMALS: u8 = 9;
     pub const SERIALIZED_SIZE: usize = 8;
 
     pub fn get_underlying_amount_per_contract(&self) -> f64 {
         convert_fixed_point_to_f64(
             self.underlying_amount_per_contract.into(),
-            Self::UNDERLYING_AMOUNT_PER_CONTRACT_DECIMALS,
+            self.underlying_amound_per_contract_decimals,
         )
     }
 }

--- a/tests/utilities/instruments/psyoptionsAmericanInstrument.ts
+++ b/tests/utilities/instruments/psyoptionsAmericanInstrument.ts
@@ -47,7 +47,7 @@ export class PsyoptionsAmericanInstrumentClass implements Instrument {
   }
 
   static async addInstrument(context: Context) {
-    await context.addInstrument(getAmericanOptionsInstrumentProgram().programId, false, 2, 7, 3, 3, 4);
+    await context.addInstrument(getAmericanOptionsInstrumentProgram().programId, false, 3, 7, 3, 3, 4);
     await context.riskEngine.setInstrumentType(getAmericanOptionsInstrumentProgram().programId, InstrumentType.Option);
   }
 
@@ -57,14 +57,18 @@ export class PsyoptionsAmericanInstrumentClass implements Instrument {
     const optionMarket = this.OptionMarket.optionMarketKey.toBytes();
 
     const underlyingamountPerContract = op.underlyingAmountPerContract.toBuffer("le", 8);
-    const expirationtime = op.expirationUnixTimestamp.toBuffer("le", 8);
-    const strikeprice = op.quoteAmountPerContract.toBuffer("le", 8);
+    const underlyingAmountPerContractDecimals = this.OptionMarket.underlyingMint.decimals;
+    const strikePrice = op.quoteAmountPerContract.toBuffer("le", 8);
+    const strikePriceDecimals = this.OptionMarket.quoteMint.decimals;
+    const expirationTime = op.expirationUnixTimestamp.toBuffer("le", 8);
     return Buffer.from(
       new Uint8Array([
         this.OptionType == OptionType.CALL ? 0 : 1,
         ...underlyingamountPerContract,
-        ...strikeprice,
-        ...expirationtime,
+        underlyingAmountPerContractDecimals,
+        ...strikePrice,
+        strikePriceDecimals,
+        ...expirationTime,
         ...mint,
         ...optionMarket,
       ])
@@ -78,6 +82,7 @@ export class PsyoptionsAmericanInstrumentClass implements Instrument {
     return [
       { pubkey: this.OptionMarket.optionMarketKey, isSigner: false, isWritable: false },
       { pubkey: this.OptionMarket.underlyingMint.mintInfoAddress, isSigner: false, isWritable: false },
+      { pubkey: this.OptionMarket.quoteMint.mintInfoAddress, isSigner: false, isWritable: false },
     ];
   }
 

--- a/tests/utilities/instruments/psyoptionsEuropeanInstrument.ts
+++ b/tests/utilities/instruments/psyoptionsEuropeanInstrument.ts
@@ -56,14 +56,18 @@ export class PsyoptionsEuropeanInstrument implements Instrument {
     const mint = this.getOptionMint().publicKey.toBytes();
     const meta = this.optionFacade.metaKey.toBytes();
     const underlyingAmountPerContract = this.optionFacade.meta.underlyingAmountPerContract.toBuffer("le", 8);
+    const underlyingAmountPerContractDecimals = this.optionFacade.meta.underlyingDecimals;
     const strikePrice = this.optionFacade.meta.strikePrice.toBuffer("le", 8);
+    const strikePriceDecimals = this.optionFacade.meta.priceDecimals;
     const expirationTimestamp = this.optionFacade.meta.expiration.toBuffer("le", 8);
 
     return Buffer.from(
       new Uint8Array([
         this.optionType == OptionType.CALL ? 0 : 1,
         ...underlyingAmountPerContract,
+        underlyingAmountPerContractDecimals,
         ...strikePrice,
+        strikePriceDecimals,
         ...expirationTimestamp,
         ...mint,
         ...meta,
@@ -249,7 +253,7 @@ export class EuroOptionsFacade {
       stableMint.publicKey,
       oracle,
       expiration,
-      8
+      9
     );
     const {
       instruction: ix,
@@ -258,13 +262,13 @@ export class EuroOptionsFacade {
     } = await createEuroMetaInstruction(
       program,
       underlyingMint.publicKey,
-      8,
+      underlyingMint.decimals,
       stableMint.publicKey,
-      8,
+      stableMint.decimals,
       expiration,
       underlyingPerContract,
       strikePrice,
-      8,
+      9,
       oracle
     );
     const transaction = new web3.Transaction().add(...preparationIxs, ix);


### PR DESCRIPTION
SDK reworks required:
- Psyoptions american instrument: rework instrument data to include `underlyingAmountPerContractDecimals` and `strikePriceDecimals` as new additional data. 
- Psyoptions american instrument: add `quoteMint` account as a new third one to `validateData` accounts
- Psyoptions euro instrument: rework instrument data to include `underlyingAmountPerContractDecimals` and `strikePriceDecimals` as new additional data.

With new fields in leg data, old rfqs are incompatible with rfqs after this change